### PR TITLE
Check whether response.image in callback is non-null befure using

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -59,7 +59,7 @@ function mapProfile(response) {
     id: response.id,
     name: response.displayName,
     email: response.emails ? response.emails[0].value : null,
-    picture: response.image.url,
+    picture: response.image ? response.image.url : null,
     provider: 'google',
     _raw: response
   });


### PR DESCRIPTION
I ran into the following error when trying to use OAuth with Google:

    TypeError: Cannot read property 'url' of undefined
    at mapProfile (/var/task/node_modules/serverless-authentication-google/lib/index.js:62:28)
    at Request._callback (/var/task/node_modules/serverless-authentication/lib/provider.js:115:46)
    at Request.self.callback (/var/task/node_modules/serverless-authentication/node_modules/request/request.js:200:22)
    at emitTwo (events.js:87:13) at Request.emit (events.js:172:7)
    at Request.<anonymous> (/var/task/node_modules/serverless-authentication/node_modules/request/request.js:1067:10)
    at emitOne (events.js:82:20) at Request.emit (events.js:169:7)
    at IncomingMessage.<anonymous> (/var/task/node_modules/serverless-authentication/node_modules/request/request.js:988:12)
    at emitNone (events.js:72:20)

Looking at the code this is caused by response.image being undefined in the callback from Google and then the callback function trying to read the url of that undefined image. This pullrequest adds a check to verify the image is not undefined before trying to access the URL.